### PR TITLE
replace references to "Hover Zoom" in options

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -107,7 +107,7 @@
     <img id="icon" src="../images/icon128.png">
 
     <div id="container">
-        <h1 id="title">Hover Zoom Options</h1>
+        <h1 id="title">Hover Free Options</h1>
 
         <div id="tabs">
             <ul>
@@ -119,7 +119,7 @@
             </ul>
             <div id="optionTab1">
                 <p><input type="checkbox" id="chkExtensionEnabled"> <label for="chkExtensionEnabled">Enable Hover
-                    Zoom</label></p>
+                    Free</label></p>
 
                 <h2>View</h2>
 
@@ -154,9 +154,9 @@
                 </div>
             </div>
             <div id="optionTab2">
-                <h2><span id="Dis-enable">Disable</span> Hover Zoom for specific sites</h2>
+                <h2><span id="Dis-enable">Disable</span> Hover Free for specific sites</h2>
 
-                <p>Enter URLs for which Hover Zoom must be <span id="Dis-enabled">disabled</span>.</p>
+                <p>Enter URLs for which Hover Free must be <span id="Dis-enabled">disabled</span>.</p>
 
                 <p><i>Examples: facebook.com, google.com/reader</i></p>
                 <table id="excludedSites">
@@ -182,7 +182,7 @@
                 <h2><input type="checkbox" id="chkWhiteListMode"> <label for="chkWhiteListMode">White list mode</label>
                 </h2>
 
-                <p>If this box is checked, Hover Zoom will be enabled <em>only</em> for the sites listed above.</p>
+                <p>If this box is checked, Hover Free will be enabled <em>only</em> for the sites listed above.</p>
             </div>
             <div id="optionTab3">
                 <table id="tableActionKeys">


### PR DESCRIPTION
replaces references to "Hover Zoom" in options with "Hover Free".
